### PR TITLE
esp_err_to_name Not Including all Errors

### DIFF
--- a/components/esp_common/CMakeLists.txt
+++ b/components/esp_common/CMakeLists.txt
@@ -19,7 +19,10 @@ else()
 
     idf_component_register(SRCS "${srcs}"
                         INCLUDE_DIRS include
-                        PRIV_REQUIRES soc)
+                        PRIV_REQUIRES soc
+                                      app_update
+                                      nvs_flash
+    )
 
     set_source_files_properties(
         "src/stack_check.c"


### PR DESCRIPTION
`esp_err_to_name` can be used to print the error enum description. However, several key `#include ` files (`nvs_flash`, `app_update`) were out of scope and have to be manually added. 

_Note: Once this PR is merged, the following command will have to be executed:_
```
git submodule update --init --recursive
```