### PR TITLE
Notify Registered protocomm_ble_event_fn Callback When Secure BLE Connection is Established

### DIFF
--- a/components/protocomm/include/transports/protocomm_ble.h
+++ b/components/protocomm/include/transports/protocomm_ble.h
@@ -30,10 +30,10 @@ extern "C" {
 typedef enum {
     // Peer is connected without any security (i.e., no PoP has been entered)
     PROTOCOMM_BLE_PEER_CONNECTED,
-    // Peer is connected securely with a valid PoP
-    PROTOCOMM_BLE_PEER_CONNECTED_SECURE,
     // Peer disconnected
     PROTOCOMM_BLE_PEER_DISCONNECTED,
+    // Peer is connected securely with a valid PoP
+    PROTOCOMM_BLE_PEER_CONNECTED_SECURE,
 } ble_event;
 
 /// type of function called when a peer device connects or disconnects

--- a/components/protocomm/include/transports/protocomm_ble.h
+++ b/components/protocomm/include/transports/protocomm_ble.h
@@ -28,7 +28,11 @@ extern "C" {
 #define BLE_UUID128_VAL_LENGTH  16
 
 typedef enum {
+    // Peer is connected without any security (i.e., no PoP has been entered)
     PROTOCOMM_BLE_PEER_CONNECTED,
+    // Peer is connected securely with a valid PoP
+    PROTOCOMM_BLE_PEER_CONNECTED_SECURE,
+    // Peer disconnected
     PROTOCOMM_BLE_PEER_DISCONNECTED,
 } ble_event;
 
@@ -100,6 +104,11 @@ esp_err_t protocomm_ble_set_manufacturer_data(uint8_t *data, uint8_t length);
 
 /// Register a callback that is called when a BLE event occurs (peer connects or disconnects)
 void protocomm_ble_register_ble_event_fn(protocomm_ble_event_fn fn);
+
+/// Get the registered BLE event callback
+///
+/// @return protocomm_ble_event_fn callback, or NULL if no callback is registered.
+protocomm_ble_event_fn protocomm_ble_get_ble_event_fn(void);
 
 /**
  * @brief   Stop Bluetooth Low Energy based transport layer for provisioning

--- a/components/protocomm/src/common/protocomm.c
+++ b/components/protocomm/src/common/protocomm.c
@@ -20,6 +20,7 @@
 #include <sys/queue.h>
 
 #include <protocomm.h>
+#include <protocomm_ble.h>
 #include <protocomm_security.h>
 
 #include "protocomm_priv.h"
@@ -285,11 +286,19 @@ static int protocomm_common_security_handler(uint32_t session_id,
     protocomm_t *pc = (protocomm_t *) priv_data;
 
     if (pc->sec && pc->sec->security_req_handler) {
-        return pc->sec->security_req_handler(pc->sec_inst,
+        esp_err_t ret = pc->sec->security_req_handler(pc->sec_inst,
                                              pc->pop, session_id,
                                              inbuf, inlen,
                                              outbuf, outlen,
                                              priv_data);
+        if (ESP_OK == ret) {
+            protocomm_ble_event_fn fn = protocomm_ble_get_ble_event_fn();
+            if (NULL != fn) {
+                fn(PROTOCOMM_BLE_PEER_CONNECTED_SECURE);
+            }
+        }
+
+        return ret;
     }
 
     return ESP_OK;

--- a/components/protocomm/src/transports/protocomm_nimble.c
+++ b/components/protocomm/src/transports/protocomm_nimble.c
@@ -426,6 +426,10 @@ void protocomm_ble_register_ble_event_fn(protocomm_ble_event_fn fn) {
     _ble_event_fn = fn;
 }
 
+protocomm_ble_event_fn protocomm_ble_get_ble_event_fn(void) {
+    return _ble_event_fn;
+}
+
 int
 gatt_svr_init(const simple_ble_cfg_t *config)
 {


### PR DESCRIPTION
Pivotal Tracker: 

[https://www.pivotaltracker.com/story/show/175585107](https://www.pivotaltracker.com/story/show/175585107)

# Problem

As of now, the `protocomm_ble_event_fn` is only called when a BLE peer connects prior to entering PoP, and when a BLE peer disconnects. This callback should also be called on a `PROTOCOMM_BLE_PEER_CONNECTED_SECURE` event, to allow the project to be notified when a secure BLE connection is established (`security1)`; 

# Solution

- Added new `ble_event` `PROTOCOMM_BLE_PEER_CONNECTED_SECURE`
- Added `protocomm_ble_get_ble_event_fn` to get previously-registered `protocomm_ble_event_fn` callback
- Call `protocomm_ble_get_ble_event_fn` if `security_req_handler` returns `ESP_OK`, passing in `PROTOCOMM_BLE_PEER_CONNECTED_SECURE` to let whoever registered `protocomm_ble_event_fn` know there is a secure BLE connection

# How has this been tested?

_Tested with ESP iOS provisioning app and printing log in `protocomm_ble_event_fn` callback when a `PROTOCOMM_BLE_PEER_CONNECTED_SECURE` event is passed_

- [x] Callback is successfully notified when a secure connection is made (i.e., after PoP is passed and proves to be successful)
- [x] Callback does not get notified if incorrect PoP was entered