### PR TITLE
Add Callback to check if Secure Connection Exists

### DIFF
--- a/components/protocomm/include/security/protocomm_security.h
+++ b/components/protocomm/include/security/protocomm_security.h
@@ -101,6 +101,14 @@ typedef struct protocomm_security {
                          uint32_t session_id,
                          const uint8_t *inbuf, ssize_t inlen,
                          uint8_t *outbuf, ssize_t *outlen);
+
+    /**
+     * Function which checks whether or not a secure connection has
+     * been established
+     *
+     * note: only relevant to security1
+     */
+    bool (*secure_session_established)(protocomm_security_handle_t handle);
 } protocomm_security_t;
 
 #ifdef __cplusplus

--- a/components/protocomm/src/common/protocomm.c
+++ b/components/protocomm/src/common/protocomm.c
@@ -291,14 +291,13 @@ static int protocomm_common_security_handler(uint32_t session_id,
                                              inbuf, inlen,
                                              outbuf, outlen,
                                              priv_data);
-        if (ESP_OK == ret) {
+        if (ESP_OK == ret && NULL != pc->sec->secure_session_established) {
             protocomm_ble_event_fn fn = protocomm_ble_get_ble_event_fn();
-            if (NULL != fn) {
+
+            if (NULL != fn && pc->sec->secure_session_established(pc->sec_inst)) {
                 fn(PROTOCOMM_BLE_PEER_CONNECTED_SECURE);
             }
         }
-
-        return ret;
     }
 
     return ESP_OK;

--- a/components/protocomm/src/security/security1.c
+++ b/components/protocomm/src/security/security1.c
@@ -171,7 +171,7 @@ static esp_err_t handle_session_command1(session_t *cur_session,
     resp->sec1 = out;
 
     cur_session->state = SESSION_STATE_DONE;
-    ESP_LOGD(TAG, "Secure session established successfully");
+    ESP_LOGI(TAG, "Secure session established successfully");
     return ESP_OK;
 }
 
@@ -572,6 +572,15 @@ static esp_err_t sec1_req_handler(protocomm_security_handle_t handle,
     return ESP_OK;
 }
 
+static bool sec1_secure_session_established(protocomm_security_handle_t handle) {
+    session_t *cur_session = (session_t *) handle;
+    if (NULL == cur_session) {
+        return false;
+    }
+
+    return cur_session->state == SESSION_STATE_DONE;
+}
+
 const protocomm_security_t protocomm_security1 = {
     .ver = 1,
     .init = sec1_init,
@@ -581,4 +590,5 @@ const protocomm_security_t protocomm_security1 = {
     .security_req_handler = sec1_req_handler,
     .encrypt = sec1_decrypt, /* Encrypt == decrypt for AES-CTR */
     .decrypt = sec1_decrypt,
+    .secure_session_established = sec1_secure_session_established,
 };


### PR DESCRIPTION
Pivotal Tracker: [https://www.pivotaltracker.com/story/show/176120971](https://www.pivotaltracker.com/story/show/176120971)

# Problem

`PROTOCOMM_BLE_PEER_CONNECTED_SECURE` is being published to the system regardless of PoP validity. 

After digging into _why_ this was occurring now and was not noticed previously, I found that there are two messages sent to establish a secure BLE connection (due to size, I presume); I found that the PoP is validated as part of the second message, meaning that since the PoP was not being checked for the first portion of the message, the security handler would always return `ESP_OK`, causing `PROTOCOMM_BLE_PEER_CONNECTED_SECURE` to published prematurely. This was not initially caught when testing the UI (Adapt, where device flashes blue on secure BLE connection) because the two messages are sent back-to-back, causing the UI to flash blue for only a second (if at all). However, if you were to use the _stock_ iOS provisioning app (ESP BLE Provisioning), there is a bug in the disconnection sequence, where the mobile device never actually disconnects from the unit, causing the UI to flash blue until the application is quit. 

# Solution

- Add new function definition `secure_session_established` to `protocomm_security_t` (only relevant to `security1`) which checks whether or not the current session is secure or not

# How has this been tested?

- [x] Invalid PoP does not trigger `PROTOCOMM_BLE_PEER_CONNECTED_SECURE` publish, reguardless of app used for testing
- [x] Pushing a valid PoP notifies system of `PROTOCOMM_BLE_PEER_CONNECTED_SECURE`