### PR TITLE
Specify idf_tools.py Uses Python3

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8]
 
     steps:
       - name: Checkout

--- a/tools/idf_tools.py
+++ b/tools/idf_tools.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding=utf-8
 #
 # This script helps installing tools required to use the ESP-IDF, and updating PATH


### PR DESCRIPTION
Pivotal Tracker: N/A

# Problem

Though it is not specified, `tools/idf_tools.py` requires Python 3.x. On some developers machines, the default python version is 2.7, so the tools are not installed correctly. 

```
Installing ESP-IDF tools
Installing tools: xtensa-esp32-elf, xtensa-esp32s2-elf, esp32ulp-elf, esp32s2ulp-elf, openocd-esp32
Skipping xtensa-esp32-elf@esp-2020r3-8.4.0 (already installed)
Skipping xtensa-esp32s2-elf@esp-2020r3-8.4.0 (already installed)
Skipping esp32ulp-elf@2.28.51-esp-20191205 (already installed)
Skipping esp32s2ulp-elf@2.28.51-esp-20191205 (already installed)
Skipping openocd-esp32@v0.10.0-esp32-20200709 (already installed)
Installing Python environment and packages
Installing Python packages from /Users/lapumb/src/uvangel_firmware/toolchain/esp-idf/requirements.txt
DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support pip 21.0 will remove support for this functionality.
Ignoring None: markers 'sys_platform == "win32"' don't match your environment
Requirement already satisfied: setuptools>=21 in ./toolchain/python_env/idf4.2_py2.7_env/lib/python2.7/site-packages (from -r /Users/lapumb/src/uvangel_firmware/toolchain/esp-idf/requirements.txt (line 4)) (44.1.1)
Collecting click>=5.0
  Using cached click-7.1.2-py2.py3-none-any.whl (82 kB)
Collecting pyserial>=3.0
  Using cached pyserial-3.5-py2.py3-none-any.whl (90 kB)
Processing /Users/lapumb/Library/Caches/pip/wheels/5f/11/0c/aad680baf5ef4fbcbab992c9f03e1130357e0c173a4fdabfff/future-0.18.2-py2-none-any.whl
Collecting cryptography>=2.1.4
  Using cached cryptography-3.3.1-cp27-cp27m-macosx_10_10_x86_64.whl (1.8 MB)
Collecting pyparsing<2.4.0,>=2.0.3
  Using cached pyparsing-2.3.1-py2.py3-none-any.whl (61 kB)
Collecting pyelftools>=0.22
  Using cached pyelftools-0.27-py2.py3-none-any.whl (151 kB)
Collecting gdbgui==0.13.2.0
  Using cached gdbgui-0.13.2.0.tar.gz (848 kB)
Collecting pygdbmi<=0.9.0.2
  Using cached pygdbmi-0.9.0.2.tar.gz (17 kB)
Collecting reedsolo<=1.5.4,>=1.5.3
  Using cached reedsolo-1.5.4.tar.gz (271 kB)
Collecting bitstring>=3.1.6
  Using cached bitstring-3.1.7.tar.gz (195 kB)
Collecting ecdsa>=0.16.0
  Using cached ecdsa-0.16.1-py2.py3-none-any.whl (104 kB)
Collecting ipaddress; python_version < "3"
  Using cached ipaddress-1.0.23-py2.py3-none-any.whl (18 kB)
Collecting six>=1.4.1
  Using cached six-1.15.0-py2.py3-none-any.whl (10 kB)
Collecting enum34; python_version < "3"
  Using cached enum34-1.1.10-py2-none-any.whl (11 kB)
direnv: ([/usr/local/bin/direnv export zsh]) is taking a while to execute. Use CTRL-C to give up.
Collecting cffi>=1.12
  Using cached cffi-1.14.4-cp27-cp27m-macosx_10_9_x86_64.whl (175 kB)
Collecting Flask<1.0,>=0.12.2
  Using cached Flask-0.12.5-py2.py3-none-any.whl (81 kB)
Collecting Flask-Compress<2.0,>=1.4.0
  Using cached Flask-Compress-1.8.0.tar.gz (10 kB)
Collecting Flask-SocketIO<3.0,>=2.9
  Using cached Flask_SocketIO-2.9.6-py2.py3-none-any.whl (16 kB)
Collecting gevent<2.0,>=1.2.2
  Using cached gevent-1.5.0-cp27-cp27m-macosx_10_9_x86_64.whl (1.7 MB)
Collecting Pygments<3.0,>=2.2.0
  Using cached Pygments-2.5.2-py2.py3-none-any.whl (896 kB)
Collecting pycparser
  Using cached pycparser-2.20-py2.py3-none-any.whl (112 kB)
Collecting itsdangerous>=0.21
  Using cached itsdangerous-1.1.0-py2.py3-none-any.whl (16 kB)
Collecting Werkzeug<1.0,>=0.7
  Using cached Werkzeug-0.16.1-py2.py3-none-any.whl (327 kB)
Collecting Jinja2>=2.4
  Using cached Jinja2-2.11.2-py2.py3-none-any.whl (125 kB)
Collecting brotli
  Using cached Brotli-1.0.9-cp27-cp27m-macosx_10_9_x86_64.whl (417 kB)
Collecting python-socketio>=1.6.1
  Using cached python_socketio-5.0.4-py2.py3-none-any.whl (52 kB)
Collecting greenlet>=0.4.14; platform_python_implementation == "CPython"
  Using cached greenlet-1.0.0-cp27-cp27m-macosx_10_14_x86_64.whl (86 kB)
Collecting MarkupSafe>=0.23
  Using cached MarkupSafe-1.1.1-cp27-cp27m-macosx_10_6_intel.whl (17 kB)
ERROR: Could not find a version that satisfies the requirement bidict>=0.21.0 (from python-socketio>=1.6.1->Flask-SocketIO<3.0,>=2.9->gdbgui==0.13.2.0->-r /Users/lapumb/src/uvangel_firmware/toolchain/esp-idf/requirements.txt (line 14)) (from versions: 0.1.5, 0.2.1, 0.3.0, 0.3.1, 0.9.0rc0, 0.9.0.post1, 0.10.0, 0.10.0.post1, 0.11.0, 0.12.0.post1, 0.13.0, 0.13.1, 0.14.0, 0.14.1, 0.14.2, 0.15.0.dev0, 0.15.0.dev1, 0.15.0rc1, 0.15.0, 0.16.0, 0.17.0, 0.17.1, 0.17.2, 0.17.3, 0.17.4, 0.17.5, 0.18.0, 0.18.1, 0.18.2, 0.18.3, 0.18.4)
ERROR: No matching distribution found for bidict>=0.21.0 (from python-socketio>=1.6.1->Flask-SocketIO<3.0,>=2.9->gdbgui==0.13.2.0->-r /Users/lapumb/src/uvangel_firmware/toolchain/esp-idf/requirements.txt (line 14))
Traceback (most recent call last):
  File "/Users/lapumb/src/uvangel_firmware/toolchain/esp-idf/tools/idf_tools.py", line 1492, in <module>
    main(sys.argv[1:])
  File "/Users/lapumb/src/uvangel_firmware/toolchain/esp-idf/tools/idf_tools.py", line 1488, in main
    action_func(args)
  File "/Users/lapumb/src/uvangel_firmware/toolchain/esp-idf/tools/idf_tools.py", line 1215, in action_install_python_env
    subprocess.check_call(run_args, stdout=sys.stdout, stderr=sys.stderr)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 190, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/Users/lapumb/src/uvangel_firmware/toolchain/python_env/idf4.2_py2.7_env/bin/python', '-m', 'pip', 'install', '--no-warn-script-location', '-r', '/Users/lapumb/src/uvangel_firmware/toolchain/esp-idf/requirements.txt']' returned non-zero exit status 1
Adding ESP-IDF tools to PATH...
Using Python interpreter in /Users/lapumb/src/uvangel_firmware/toolchain/python_env/idf4.2_py2.7_env/bin/python
Checking if Python packages are up to date...
The following Python requirements are not satisfied:
click>=5.0
pyserial>=3.0
future>=0.15.2
cryptography>=2.1.4
pyparsing>=2.0.3,<2.4.0
pyelftools>=0.22
gdbgui==0.13.2.0
pygdbmi<=0.9.0.2
reedsolo>=1.5.3,<=1.5.4
bitstring>=3.1.6
ecdsa>=0.16.0
To install the missing packages, please run "/Users/lapumb/src/uvangel_firmware/toolchain/esp-idf/install.sh"
```

# Solution

- Specify Python3 to run `idf_tools.py`

`#!/usr/bin/env python3`

# How has this been tested?

- [x] Requirements are installed using Python3
