### PR TITLE
air-222_esp_ota_fail_msg_improvements

### DIFF
--- a/components/esp_https_ota/include/esp_https_ota.h
+++ b/components/esp_https_ota/include/esp_https_ota.h
@@ -33,6 +33,9 @@ typedef struct {
 #define ESP_ERR_HTTPS_OTA_BASE            (0x9000)
 #define ESP_ERR_HTTPS_OTA_IN_PROGRESS     (ESP_ERR_HTTPS_OTA_BASE + 1)  /* OTA operation in progress */
 
+// New routine to provide OTA Error String for OTA Publish to Cloud
+void get_ota_perform_err_str( char* ptr_err_str );
+
 /**
  * @brief    HTTPS OTA Firmware upgrade.
  *

--- a/components/esp_https_ota/src/esp_https_ota.c
+++ b/components/esp_https_ota/src/esp_https_ota.c
@@ -43,6 +43,16 @@ struct esp_https_ota_handle {
 
 typedef struct esp_https_ota_handle esp_https_ota_t;
 
+// New OTA Error String for OTA Publish to Cloud
+#define MAX_OTA_PERFORM_ERROR_MSG_LENGTH 31             // Keep size same as MAX_OTA_ERROR_MSG_LENGTH
+
+static char ota_perform_err_str[MAX_OTA_PERFORM_ERROR_MSG_LENGTH] = {0};
+
+void get_ota_perform_err_str( char* ptr_err_str )
+{
+    strncpy(ptr_err_str, ota_perform_err_str, MAX_OTA_PERFORM_ERROR_MSG_LENGTH);
+}
+
 static bool process_again(int status_code)
 {
     switch (status_code) {
@@ -257,10 +267,12 @@ esp_err_t esp_https_ota_perform(esp_https_ota_handle_t https_ota_handle)
     esp_https_ota_t *handle = (esp_https_ota_t *)https_ota_handle;
     if (handle == NULL) {
         ESP_LOGE(TAG, "esp_https_ota_perform: Invalid argument");
+        strncpy(ota_perform_err_str, "INVALID OTA HANDLE", MAX_OTA_PERFORM_ERROR_MSG_LENGTH);
         return ESP_ERR_INVALID_ARG;
     }
     if (handle->state < ESP_HTTPS_OTA_BEGIN) {
         ESP_LOGE(TAG, "esp_https_ota_perform: Invalid state");
+        strncpy(ota_perform_err_str, "INVALID OTA STATE", MAX_OTA_PERFORM_ERROR_MSG_LENGTH);
         return ESP_FAIL;
     }
 
@@ -271,6 +283,7 @@ esp_err_t esp_https_ota_perform(esp_https_ota_handle_t https_ota_handle)
             err = esp_ota_begin(handle->update_partition, OTA_SIZE_UNKNOWN, &handle->update_handle);
             if (err != ESP_OK) {
                 ESP_LOGE(TAG, "esp_ota_begin failed (%s)", esp_err_to_name(err));
+                strncpy(ota_perform_err_str, "esp_ota_begin() FAILED", MAX_OTA_PERFORM_ERROR_MSG_LENGTH);
                 return err;
             }
             handle->state = ESP_HTTPS_OTA_IN_PROGRESS;
@@ -300,6 +313,7 @@ esp_err_t esp_https_ota_perform(esp_https_ota_handle_t https_ota_handle)
                  */
                 if ((errno == ENOTCONN || errno == ECONNRESET || errno == ECONNABORTED) && !is_recv_complete) {
                     ESP_LOGE(TAG, "Connection closed, errno = %d", errno);
+                    strncpy(ota_perform_err_str, "UNEXPECTED CLOSED CONNECTION", MAX_OTA_PERFORM_ERROR_MSG_LENGTH);
                     return ESP_FAIL;
                 } else if (!is_recv_complete) {
                     return ESP_ERR_HTTPS_OTA_IN_PROGRESS;
@@ -308,12 +322,14 @@ esp_err_t esp_https_ota_perform(esp_https_ota_handle_t https_ota_handle)
             } else if (data_read > 0) {
                 return _ota_write(handle, (const void *)handle->ota_upgrade_buf, data_read);
             } else {
+                strncpy(ota_perform_err_str, "UNEXPECTED END OF DATA", MAX_OTA_PERFORM_ERROR_MSG_LENGTH);
                 return ESP_FAIL;
             }
             handle->state = ESP_HTTPS_OTA_SUCCESS;
             break;
          default:
             ESP_LOGE(TAG, "Invalid ESP HTTPS OTA State");
+            strncpy(ota_perform_err_str, "INVALID OTA PROCESS STATE", MAX_OTA_PERFORM_ERROR_MSG_LENGTH);
             return ESP_FAIL;
             break;
     }
@@ -379,8 +395,12 @@ int esp_https_ota_get_image_len_read(esp_https_ota_handle_t https_ota_handle)
 
 esp_err_t esp_https_ota(const esp_http_client_config_t *config)
 {
+    // Clear new ota_perform_err_str
+    memset(ota_perform_err_str, 0, sizeof(ota_perform_err_str));
+    
     if (!config) {
         ESP_LOGE(TAG, "esp_http_client config not found");
+        strncpy(ota_perform_err_str, "no esp_http_client config", MAX_OTA_PERFORM_ERROR_MSG_LENGTH);
         return ESP_ERR_INVALID_ARG;
     }    
 
@@ -391,6 +411,7 @@ esp_err_t esp_https_ota(const esp_http_client_config_t *config)
     esp_https_ota_handle_t https_ota_handle = NULL;
     esp_err_t err = esp_https_ota_begin(&ota_config, &https_ota_handle);
     if (https_ota_handle == NULL) {
+        strncpy(ota_perform_err_str, "INVALID OTA HANDLE", MAX_OTA_PERFORM_ERROR_MSG_LENGTH);
         return ESP_FAIL;
     }
 


### PR DESCRIPTION
* Added logic to store unique error description in a string variable that can be retrieved by other threads during the OTA process.