### PR TITLE
Fix esp-idf wheel build failures for esp-idf v4.2 tools on some M1 Macs #102

### DIFF
--- a/tools/idf_tools.py
+++ b/tools/idf_tools.py
@@ -1182,6 +1182,22 @@ def action_install(args):
         tool_obj.download(tool_version)
         tool_obj.install(tool_version)
 
+def get_wheels_dir():
+    tools_info = load_tools_info()
+    wheels_package_name = 'idf-python-wheels'
+    if wheels_package_name not in tools_info:
+        return None
+    wheels_package = tools_info[wheels_package_name]
+    recommended_version = wheels_package.get_recommended_version()
+    if recommended_version is None:
+        return None
+    wheels_dir = wheels_package.get_path_for_version(recommended_version)
+    if not os.path.exists(wheels_dir):
+        return None
+    return wheels_dir
+
+
+
 
 def action_install_python_env(args):
     idf_python_env_path, _, virtualenv_python = get_python_env_path()
@@ -1212,6 +1228,16 @@ def action_install_python_env(args):
     run_args += ['-r', requirements_txt]
     if args.extra_wheels_dir:
         run_args += ['--find-links', args.extra_wheels_dir]
+    if args.no_index:
+        run_args += ['--no-index']
+    if args.extra_wheels_url:
+        run_args += ['--extra-index-url', args.extra_wheels_url]
+
+    wheels_dir = get_wheels_dir()
+    if wheels_dir is not None:
+        run_args += ['--find-links', wheels_dir]
+
+
     info('Installing Python packages from {}'.format(requirements_txt))
     subprocess.check_call(run_args, stdout=sys.stdout, stderr=sys.stderr)
 
@@ -1415,6 +1441,9 @@ def main(argv):
                                     action='store_true')
     install_python_env.add_argument('--extra-wheels-dir', help='Additional directories with wheels ' +
                                     'to use during installation')
+
+    install_python_env.add_argument('--extra-wheels-url', help='Additional URL with wheels', default='https://dl.espressif.com/pypi')
+    install_python_env.add_argument('--no-index', help='Work offline without retrieving wheels index')
 
     if IDF_MAINTAINER:
         add_version = subparsers.add_parser('add-version', help='Add or update download info for a version')


### PR DESCRIPTION
Ticket Tracking: N/A

# Problem

The v4.2 tools have a bug that forces them to look for an inappropriate wheels version. 
See the full problem description in [`uvangel_air_v21 PR102](https://github.com/UVAngel/uvangel_air_v2/pull/102) .
This bug is fixed on the esp-idf v4.3 release branch.

# Solution

This PR is the esp-idf toolchain part of the solution for  [`uvangel_air_v21 PR102](https://github.com/UVAngel/uvangel_air_v2/pull/102).

- Found the esp-idf  bug fix from the v4.3 branch and applied it to the `tools/idf_tools.py` script. 

# How has this been tested?

* Builds on Rocky's M1 Mac, which has a default python installation of v3.11.10.
* Builds on Luke's M1 Mac which has a default python installation of v3.10.12
