### PR TITLE
AIR-460 - Improved Job Failed Strings In esp_https_ota_begin

### DIFF
--- a/components/esp_https_ota/src/esp_https_ota.c
+++ b/components/esp_https_ota/src/esp_https_ota.c
@@ -151,6 +151,21 @@ esp_err_t esp_https_ota_begin(esp_https_ota_config_t *ota_config, esp_https_ota_
         if (handle) {
             *handle = NULL;
         }
+
+        // set failure string to appropriate cause(s) to be published in job status notifications
+        strncpy(ota_perform_err_str, "Invalid ", MAX_OTA_PERFORM_ERROR_MSG_LENGTH);
+        if (handle == NULL)
+        {
+            strcat(ota_perform_err_str, "handle ");
+        }
+        if (ota_config == NULL) {
+            strcat(ota_perform_err_str, "otacfg ");
+        } else {
+            if (ota_config->http_config == NULL) {
+                strcat(ota_perform_err_str, "httpcfg");
+            }
+        }
+
         return ESP_ERR_INVALID_ARG;
     }
 
@@ -158,6 +173,8 @@ esp_err_t esp_https_ota_begin(esp_https_ota_config_t *ota_config, esp_https_ota_
     if (!ota_config->http_config->cert_pem) {
         ESP_LOGE(TAG, "Server certificate not found in esp_http_client config");
         *handle = NULL;
+        // set failure string to be published in job status notifications
+        strncpy(ota_perform_err_str, "no server cert", MAX_OTA_PERFORM_ERROR_MSG_LENGTH);
         return ESP_ERR_INVALID_ARG;
     }
 #endif
@@ -166,6 +183,8 @@ esp_err_t esp_https_ota_begin(esp_https_ota_config_t *ota_config, esp_https_ota_
     if (!https_ota_handle) {
         ESP_LOGE(TAG, "Couldn't allocate memory to upgrade data buffer");
         *handle = NULL;
+        // set failure string to be published in job status notifications
+        strncpy(ota_perform_err_str, "fail calloc data buffer", MAX_OTA_PERFORM_ERROR_MSG_LENGTH);
         return ESP_ERR_NO_MEM;
     }
     
@@ -174,12 +193,16 @@ esp_err_t esp_https_ota_begin(esp_https_ota_config_t *ota_config, esp_https_ota_
     if (https_ota_handle->http_client == NULL) {
         ESP_LOGE(TAG, "Failed to initialise HTTP connection");
         err = ESP_FAIL;
+        // set failure string to be published in job status notifications
+        strncpy(ota_perform_err_str, "fail http client init", MAX_OTA_PERFORM_ERROR_MSG_LENGTH);
         goto failure;
     }
 
     err = _http_connect(https_ota_handle->http_client);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "Failed to establish HTTP connection");
+        // set failure string to be published in job status notifications
+        strncpy(ota_perform_err_str, "fail http connection", MAX_OTA_PERFORM_ERROR_MSG_LENGTH);
         goto http_cleanup;
     }
 
@@ -189,6 +212,8 @@ esp_err_t esp_https_ota_begin(esp_https_ota_config_t *ota_config, esp_https_ota_
     if (https_ota_handle->update_partition == NULL) {
         ESP_LOGE(TAG, "Passive OTA partition not found");
         err = ESP_FAIL;
+        // set failure string to be published in job status notifications
+        strncpy(ota_perform_err_str, "no ota partition", MAX_OTA_PERFORM_ERROR_MSG_LENGTH);
         goto http_cleanup;
     }
     ESP_LOGI(TAG, "Writing to partition subtype %d at offset 0x%x",
@@ -200,6 +225,8 @@ esp_err_t esp_https_ota_begin(esp_https_ota_config_t *ota_config, esp_https_ota_
     if (!https_ota_handle->ota_upgrade_buf) {
         ESP_LOGE(TAG, "Couldn't allocate memory to upgrade data buffer");
         err = ESP_ERR_NO_MEM;
+        // set failure string to be published in job status notifications
+        strncpy(ota_perform_err_str, "fail malloc upgrade buffer", MAX_OTA_PERFORM_ERROR_MSG_LENGTH);
         goto http_cleanup;
     }
     https_ota_handle->ota_upgrade_buf_size = alloc_size;
@@ -411,7 +438,8 @@ esp_err_t esp_https_ota(const esp_http_client_config_t *config)
     esp_https_ota_handle_t https_ota_handle = NULL;
     esp_err_t err = esp_https_ota_begin(&ota_config, &https_ota_handle);
     if (https_ota_handle == NULL) {
-        strncpy(ota_perform_err_str, "INVALID OTA HANDLE", MAX_OTA_PERFORM_ERROR_MSG_LENGTH);
+        // eliminated the setting of ota_perform_err_str to "INVALID OTA HANDLE" so that the more detailed
+        //failure strings from esp_https_ota_begin() can be used in the publishing of the job notices 
         return ESP_FAIL;
     }
 

--- a/components/esp_https_ota/src/esp_https_ota.c
+++ b/components/esp_https_ota/src/esp_https_ota.c
@@ -438,8 +438,12 @@ esp_err_t esp_https_ota(const esp_http_client_config_t *config)
     esp_https_ota_handle_t https_ota_handle = NULL;
     esp_err_t err = esp_https_ota_begin(&ota_config, &https_ota_handle);
     if (https_ota_handle == NULL) {
-        // eliminated the setting of ota_perform_err_str to "INVALID OTA HANDLE" so that the more detailed
-        //failure strings from esp_https_ota_begin() can be used in the publishing of the job notices 
+        // Prevent an undesired empty ota_perform_err_str
+        if ( 0 == strlen(ota_perform_err_str) )
+        {
+            // We do not know what failed in esp_https_ota_begin(), so use a general message - where to look
+            strncpy(ota_perform_err_str, "https_ota_begin() failed", MAX_OTA_PERFORM_ERROR_MSG_LENGTH);
+        }
         return ESP_FAIL;
     }
 


### PR DESCRIPTION
* Replace the general failure string, "INVALID_OTA_HANDLE" with more descriptive strings that pertain to the actual reason why esp_https_ota_begin() actually failed