### PR TITLE
OTA FAILURES NULL TRANSPORT POINTERS DEBUG

### DIFF
--- a/components/esp_http_client/esp_http_client.c
+++ b/components/esp_http_client/esp_http_client.c
@@ -881,9 +881,12 @@ int esp_http_client_read(esp_http_client_handle_t client, char *buffer, int len)
                     /* ...and lowering the message severity, as closed connection from server side is expected in chunked transport */
                     sev = ESP_LOG_DEBUG;
                 }
+                // TL NOTE: Saw this when the STALL occurred - errno = 11 - "No more processes"
                 ESP_LOG_LEVEL(sev, TAG, "esp_transport_read returned:%d and errno:%d ", rlen, errno);
             }
             if (rlen < 0 && ridx == 0) {
+                // In order for rlen to be "-1" (ESP_FAIL) either the transport pointer or its _read pointer is NULL
+                // This is determined by the error logic in esp_transport_read()
                 return ESP_FAIL;
             } else {
                 return ridx;
@@ -1030,6 +1033,9 @@ static esp_err_t esp_http_client_connect(esp_http_client_handle_t client)
     if (client->state < HTTP_STATE_CONNECTED) {
         ESP_LOGD(TAG, "Begin connect to: %s://%s:%d", client->connection_info.scheme, client->connection_info.host, client->connection_info.port);
         client->transport = esp_transport_list_get_transport(client->transport_list, client->connection_info.scheme);
+
+        ESP_LOGI(TAG, "PTRDBG - esp_http_client_connect() - client->transport: %p", client->transport);
+
         if (client->transport == NULL) {
             ESP_LOGE(TAG, "No transport found");
 #ifndef CONFIG_ESP_HTTP_CLIENT_ENABLE_HTTPS
@@ -1040,6 +1046,7 @@ static esp_err_t esp_http_client_connect(esp_http_client_handle_t client)
             return ESP_ERR_HTTP_INVALID_TRANSPORT;
         }
         if (!client->is_async) {
+            ESP_LOGI(TAG, "PTRDBG - esp_http_client_connect() - calling esp_transport_connect()");
             if (esp_transport_connect(client->transport, client->connection_info.host, client->connection_info.port, client->timeout_ms) < 0) {
                 ESP_LOGE(TAG, "Connection failed, sock < 0");
                 return ESP_ERR_HTTP_CONNECT;

--- a/components/esp_https_ota/src/esp_https_ota.c
+++ b/components/esp_https_ota/src/esp_https_ota.c
@@ -355,6 +355,9 @@ esp_err_t esp_https_ota_perform(esp_https_ota_handle_t https_ota_handle)
             } else if (data_read > 0) {
                 return _ota_write(handle, (const void *)handle->ota_upgrade_buf, data_read);
             } else {
+                // we are here because esp_http_client_read() set data_read = "-1" (ESP_FAIL) because it is not > 0 or == 0
+                // esp_http_client_read() returns an ESP_FAIL if esp_transport_read() returns a "-1" 
+                // esp_transport_read() will return a "-1" if the esp_transport_handle_t passed in is NULL or its esp_transport->_read() pointer is NULL 
                 strncpy(ota_perform_err_str, "UNEXPECTED END OF DATA", MAX_OTA_PERFORM_ERROR_MSG_LENGTH);
                 return ESP_FAIL;
             }

--- a/components/tcp_transport/transport.c
+++ b/components/tcp_transport/transport.c
@@ -17,6 +17,8 @@
 #include <string.h>
 #include <esp_tls.h>
 
+#include "esp_debug_helpers.h"
+
 #include "sys/queue.h"
 #include "esp_log.h"
 
@@ -161,8 +163,20 @@ esp_err_t esp_transport_destroy(esp_transport_handle_t t)
 int esp_transport_connect(esp_transport_handle_t t, const char *host, int port, int timeout_ms)
 {
     int ret = -1;
+    // Determine if one of the pointers is NULL
+    // If so, it will cause the INVALID_OTA_HANDLE OTA Job Failure
+    if (NULL == t) {
+        ESP_LOGI(TAG, "PTRDBG - esp_transport_connect() - t = NULL");
+    }
+    if (NULL == t->_connect) {
+        ESP_LOGI(TAG, "PTRDBG - esp_transport_connect() - t->_connect = NULL");
+    }
+
     if (t && t->_connect) {
         return t->_connect(t, host, port, timeout_ms);
+    }
+    else {
+        esp_backtrace_print(15);
     }
     return ret;
 }
@@ -178,8 +192,21 @@ int esp_transport_connect_async(esp_transport_handle_t t, const char *host, int 
 
 int esp_transport_read(esp_transport_handle_t t, char *buffer, int len, int timeout_ms)
 {
+
+    // Determine if one of the pointers is NULL
+    // If so, it will cause the UNEXPECTED_END_OF_DATA Job Failure
+    if (NULL == t) {
+        ESP_LOGI(TAG, "PTRDBG - esp_transport_read() - t = NULL");
+    }
+    if (NULL == t->_read) {
+        ESP_LOGI(TAG, "PTRDBG - esp_transport_read() - _read = NULL");
+    }
+
     if (t && t->_read) {
         return t->_read(t, buffer, len, timeout_ms);
+    }
+    else {
+        esp_backtrace_print(15);
     }
     return -1;
 }
@@ -254,6 +281,9 @@ esp_err_t esp_transport_set_func(esp_transport_handle_t t,
     t->_destroy = _destroy;
     t->_connect_async = NULL;
     t->_parent_transfer = esp_transport_get_default_parent;
+
+    ESP_LOGI(TAG, "PTRDBG - esp_trans_set_func() - _connect: %p, _read: %p", _connect, _read);
+
     return ESP_OK;
 }
 

--- a/components/tcp_transport/transport_ssl.c
+++ b/components/tcp_transport/transport_ssl.c
@@ -159,6 +159,7 @@ static int ssl_read(esp_transport_handle_t t, char *buffer, int len, int timeout
     }
     ret = esp_tls_conn_read(ssl->tls, (unsigned char *)buffer, len);
     if (ret < 0) {
+        // TL NOTE: Saw this when the STALL occurred - errno = 11 - "No more processes"
         ESP_LOGE(TAG, "esp_tls_conn_read error, errno=%s", strerror(errno));
         esp_transport_set_errors(t, ssl->tls->error_handle);
     }
@@ -297,6 +298,9 @@ esp_transport_handle_t esp_transport_ssl_init(void)
     transport_ssl_t *ssl = calloc(1, sizeof(transport_ssl_t));
     ESP_TRANSPORT_MEM_CHECK(TAG, ssl, return NULL);
     esp_transport_set_context_data(t, ssl);
+
+    ESP_LOGI(TAG, "PTRDBG - esp_transport_ssl_init() - ssl_connect: %p, ssl_read: %p", ssl_connect, ssl_read);
+
     esp_transport_set_func(t, ssl_connect, ssl_read, ssl_write, ssl_close, ssl_poll_read, ssl_poll_write, ssl_destroy);
     esp_transport_set_async_connect_func(t, ssl_connect_async);
     return t;

--- a/components/tcp_transport/transport_tcp.c
+++ b/components/tcp_transport/transport_tcp.c
@@ -240,6 +240,9 @@ esp_transport_handle_t esp_transport_tcp_init(void)
     transport_tcp_t *tcp = calloc(1, sizeof(transport_tcp_t));
     ESP_TRANSPORT_MEM_CHECK(TAG, tcp, return NULL);
     tcp->sock = -1;
+
+    ESP_LOGI(TAG, "PTRDBG - esp_transport_tcp_init() - tcp_connect: %p, tcp_read: %p", tcp_connect, tcp_read);
+
     esp_transport_set_func(t, tcp_connect, tcp_read, tcp_write, tcp_close, tcp_poll_read, tcp_poll_write, tcp_destroy);
     esp_transport_set_context_data(t, tcp);
 

--- a/components/tcp_transport/transport_ws.c
+++ b/components/tcp_transport/transport_ws.c
@@ -468,6 +468,8 @@ esp_transport_handle_t esp_transport_ws_init(esp_transport_handle_t parent_handl
         return NULL;
     });
 
+    ESP_LOGI(TAG, "PTRDBG - esp_transport_ws_init() - ws_connect: %p, ws_read: %p", ws_connect, ws_read);
+
     esp_transport_set_func(t, ws_connect, ws_read, ws_write, ws_close, ws_poll_read, ws_poll_write, ws_destroy);
     // webocket underlying transfer is the payload transfer handle
     esp_transport_set_parent_transport_func(t, ws_get_payload_transport_handle);


### PR DESCRIPTION
* FOR DEBUGGING PURPOSES ONLY - NOT MEANT TO BE MERGED INTO MAIN BRANCH

* Added Transport Pointer Debug - In trying to resolve INVALID_OTA_HANDLE and UNEXPECTED_END_OF_DATA OTA failures
* Will be able to determine if the transport pointer is bad or the _connect or _read pointers are bad
* Will dump the Back Trace of function calls when one of the pointers is NULL